### PR TITLE
Added text colors to sold seat for man and woman

### DIFF
--- a/ALBusSeatView/Classes/ALBusSeatView.swift
+++ b/ALBusSeatView/Classes/ALBusSeatView.swift
@@ -249,8 +249,16 @@ extension ALBusSeatView:  UICollectionViewDelegate, UICollectionViewDataSource, 
             cell.label.textColor = config.seatNumberSelectedColor
         case .soldMan:
             cell.coverView.backgroundColor = config.seatSoldManBGColor
+            // Change text color if the config has a color for seat sold man
+            if let textColor = config.seatSoldManTextColor {
+                cell.label.textColor = textColor
+            }
         case .soldWoman:
             cell.coverView.backgroundColor = config.seatSoldWomanBGColor
+            // Change text color if the config has a color for seat sold woman
+            if let textColor = config.seatSoldWomanTextColor {
+                cell.label.textColor = textColor
+            }
         case .none:
             cell.coverView.backgroundColor = .clear
             cell.isUserInteractionEnabled = false

--- a/ALBusSeatView/Classes/ALBusSeatViewConfig.swift
+++ b/ALBusSeatView/Classes/ALBusSeatViewConfig.swift
@@ -29,10 +29,10 @@ public class ALBusSeatViewConfig {
     open var seatSoldManBGColor: UIColor = .blue
     
     /// Seat color purchased by woman
-    open var seatSoldWomanTextColor: UIColor = .black
+    open var seatSoldWomanTextColor: UIColor? = nil
     
     /// Seat color purchased by man
-    open var seatSoldManTextColor: UIColor = .black
+    open var seatSoldManTextColor: UIColor? = nil
     
     /// Seat corner radius
     open var seatCornerRadius: CGFloat = 8.0

--- a/ALBusSeatView/Classes/ALBusSeatViewConfig.swift
+++ b/ALBusSeatView/Classes/ALBusSeatViewConfig.swift
@@ -28,6 +28,12 @@ public class ALBusSeatViewConfig {
     /// Seat color purchased by man
     open var seatSoldManBGColor: UIColor = .blue
     
+    /// Seat color purchased by woman
+    open var seatSoldWomanTextColor: UIColor = .black
+    
+    /// Seat color purchased by man
+    open var seatSoldManTextColor: UIColor = .black
+    
     /// Seat corner radius
     open var seatCornerRadius: CGFloat = 8.0
     


### PR DESCRIPTION
Currently, we can configure sold seat background colors for man and woman but not text colors. For that reason, I added two config values and set up in collectionview. I think it would be beneficial.